### PR TITLE
Add toriptables2 - Python script alternative to Nipe (Make Tor default gateway)

### DIFF
--- a/_pages/index.rst
+++ b/_pages/index.rst
@@ -616,6 +616,7 @@ Privacy
 
 - `I2P <https://geti2p.net>`_ - The Invisible Internet Project.
 - `Nipe <https://github.com/GouveaHeitor/nipe>`_ - A script to make Tor Network your default gateway.
+- `toriptables2 <https://github.com/ruped24/toriptables2>`_ - A python script alternative to Nipe. Makes Tor Network your default gateway.
 - `SecureDrop <https://freedom.press/securedrop>`_ - Open-source whistleblower submission system that media organizations can use to securely accept documents from and communicate with anonymous sources.
 - `Tor <https://www.torproject.org>`_ - The free software for enabling onion routing online anonymity.
 

--- a/_pages/index.rst
+++ b/_pages/index.rst
@@ -616,9 +616,9 @@ Privacy
 
 - `I2P <https://geti2p.net>`_ - The Invisible Internet Project.
 - `Nipe <https://github.com/GouveaHeitor/nipe>`_ - A script to make Tor Network your default gateway.
-- `toriptables2 <https://github.com/ruped24/toriptables2>`_ - A python script alternative to Nipe. Makes Tor Network your default gateway.
 - `SecureDrop <https://freedom.press/securedrop>`_ - Open-source whistleblower submission system that media organizations can use to securely accept documents from and communicate with anonymous sources.
 - `Tor <https://www.torproject.org>`_ - The free software for enabling onion routing online anonymity.
+- `toriptables2 <https://github.com/ruped24/toriptables2>`_ - A python script alternative to Nipe. Makes Tor Network your default gateway.
 
 Reverse Engineering
 ===================


### PR DESCRIPTION
[toriptables2](https://github.com/ruped24/toriptables2) is an alternative to Nipe.
It's written in python and will appeal to people who prefer using python to perl.